### PR TITLE
Add exercise space section with text and voice conversation previews

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -387,6 +387,241 @@
   overflow: hidden;
 }
 
+.exercise-space {
+  background: linear-gradient(180deg, rgba(99, 102, 241, 0.05), rgba(16, 185, 129, 0.05));
+}
+
+.exercise-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+  gap: clamp(2rem, 5vw, 4rem);
+  align-items: start;
+}
+
+.exercise-conversation {
+  display: flex;
+  flex-direction: column;
+}
+
+.conversation-card {
+  background: white;
+  border-radius: 1.5rem;
+  padding: clamp(1.8rem, 3vw, 2.2rem);
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.conversation-header {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.mode-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem;
+  border-radius: 999px;
+  background: var(--surface-muted);
+  align-self: flex-start;
+}
+
+.mode-button {
+  border: none;
+  background: transparent;
+  padding: 0.45rem 1.15rem;
+  border-radius: 999px;
+  font-weight: 600;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.mode-button:hover,
+.mode-button:focus-visible {
+  color: var(--brand-600);
+}
+
+.mode-button.active {
+  background: white;
+  color: var(--brand-600);
+  box-shadow: 0 12px 22px rgba(79, 70, 229, 0.18);
+}
+
+.mode-description {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.conversation-lines {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.conversation-line {
+  position: relative;
+  border-radius: 1.1rem;
+  padding: 1rem 1.2rem 1.1rem;
+  background: rgba(79, 70, 229, 0.08);
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.08);
+}
+
+.conversation-line.student {
+  background: white;
+}
+
+.conversation-line.coach {
+  background: rgba(79, 70, 229, 0.12);
+}
+
+.conversation-line .speaker {
+  display: block;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(79, 70, 229, 0.85);
+  margin-bottom: 0.35rem;
+}
+
+.conversation-line.student .speaker {
+  color: var(--text-muted);
+}
+
+.conversation-line p {
+  margin: 0;
+  color: var(--text-primary);
+}
+
+.conversation-meta {
+  display: inline-block;
+  margin-top: 0.6rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
+  background: white;
+  color: var(--brand-600);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.conversation-line.student .conversation-meta {
+  background: rgba(79, 70, 229, 0.1);
+}
+
+.conversation-footer {
+  background: var(--surface-muted);
+  border-radius: 1.2rem;
+  padding: 1.1rem 1.3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.conversation-footer strong {
+  font-size: 1.05rem;
+}
+
+.conversation-footer p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.exercise-insights {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.insight-card {
+  background: white;
+  border-radius: 1.4rem;
+  padding: clamp(1.6rem, 3vw, 2rem);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.insight-card.accent {
+  background: linear-gradient(145deg, rgba(79, 70, 229, 0.1), rgba(16, 185, 129, 0.12));
+}
+
+.insight-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.insight-list li {
+  background: rgba(79, 70, 229, 0.06);
+  border-radius: 1.1rem;
+  padding: 1rem 1.1rem;
+}
+
+.insight-card.accent .insight-list li {
+  background: rgba(255, 255, 255, 0.35);
+}
+
+.insight-list strong {
+  display: block;
+  margin-bottom: 0.35rem;
+  font-size: 1.02rem;
+}
+
+.insight-list p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.insight-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+}
+
+.insight-metric {
+  background: rgba(255, 255, 255, 0.65);
+  border-radius: 1rem;
+  padding: 1.1rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+.insight-card.accent .insight-metric {
+  background: rgba(255, 255, 255, 0.75);
+}
+
+.metric-value {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--brand-600);
+}
+
+.metric-label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.metric-caption {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+}
+
+.insight-note {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
 .step-number {
   position: absolute;
   top: 1.4rem;
@@ -1291,6 +1526,14 @@
   .admin-grid {
     grid-template-columns: 1fr;
   }
+
+  .exercise-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .exercise-insights {
+    width: 100%;
+  }
 }
 
 @media (max-width: 720px) {
@@ -1317,6 +1560,15 @@
 
   .student-cell {
     align-items: flex-start;
+  }
+
+  .conversation-card {
+    padding: 1.5rem;
+  }
+
+  .mode-switch {
+    width: 100%;
+    justify-content: space-between;
   }
 }
 
@@ -1349,6 +1601,10 @@
   .admin-card-controls input {
     width: 100%;
   }
+
+  .insight-metrics {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 480px) {
@@ -1372,6 +1628,20 @@
     flex-direction: column;
     align-items: flex-start;
     gap: 0.4rem;
+  }
+
+  .mode-switch {
+    flex-wrap: wrap;
+    gap: 0.35rem;
+  }
+
+  .mode-button {
+    flex: 1 1 120px;
+    text-align: center;
+  }
+
+  .conversation-footer {
+    padding: 0.95rem 1.05rem;
   }
 
   .resource-item {


### PR DESCRIPTION
## Summary
- add data models for conversational exercise modes, focus points and metrics that drive the new experience
- build an "Espace exercices" section showing text and voice Socratic dialogues with accompanying insights
- style the conversation and insight cards and tweak responsive behaviour so the new area fits the existing design

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc3e1e8e84832c85474391cbb308b9